### PR TITLE
Adds support for internal only documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ This plugin offers basically a set of annotations, along with plural variations 
 ##### @UberDocController:
 Identifies a controller that defines API resources that should be documented.
 ##### @UberDocResource:
-Identifies a controller method (aka resource) to be documented. Within an `UberDocController`, if a given method on a controller is not meant to have its documentation made available, just don't annotate it. Parameters are `requestObject`, `responseObject`, `requestIsCollection`, and `responseIsCollection`.
+Identifies a controller method (aka resource) to be documented. Within an `UberDocController`. Parameters are `requestObject`, `responseObject`, `requestIsCollection`, and `responseIsCollection`.
 ##### @UberDocError(s):
 Provides information about errors a resource can signal to the user. Parameters are `httpCode` and `errorCode`.
 ##### @UberDocHeader(s):
@@ -123,7 +123,6 @@ Example json:
    ]
 }
 ```
-
 
 ## Example usages
 
@@ -442,6 +441,17 @@ For example, if you run the integration test provided with the plugin, `UberDocS
     }
 }
 ```
+
+##### Internal Only documentation:
+In order to provide internal only documentation, `internalOnly` is supported by the following annotations:
+- @UberDocController
+- @UberDocModel
+- @UberDocProperty
+- @UberDocResource
+
+Example: `@UberDocController(internalOnly = true)`
+
+Internal only documentation can be published by setting `uberdoc.publishInternalOnly` to `true` inside application.yml or application.groovy.
 
 
 ###### Made with <3 in Berlin

--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -18,6 +18,10 @@ spring:
             check-template-location: false
 
 ---
+
+uberdoc:
+    publishInternalOnly: false
+
 grails:
     mime:
         disable:

--- a/grails-app/controllers/sample/InternalController.groovy
+++ b/grails-app/controllers/sample/InternalController.groovy
@@ -1,0 +1,24 @@
+package sample
+
+import uberdoc.annotation.UberDocController
+import uberdoc.annotation.UberDocError
+import uberdoc.annotation.UberDocQueryParam
+import uberdoc.annotation.UberDocQueryParams
+import uberdoc.annotation.UberDocResource
+import uberdoc.annotation.UberDocUriParam
+
+@UberDocController(internalOnly = true)
+class InternalController {
+
+    @UberDocResource(title = "Get Internal", description = "Gets an internal resource by id", responseObject = Internal, responseIsCollection = true)
+    @UberDocError(errorCode = "NF404", httpCode = 404)
+    @UberDocUriParam(name = "id")
+    def get(long id) {}
+
+    @UberDocResource(responseObject = Internal, responseIsCollection = true, title = "List Internals", description = "Gets a list of internal resources")
+    @UberDocQueryParams([
+            @UberDocQueryParam(name = "page", required = false, description = "custom description", sampleValue = "custom value"),
+            @UberDocQueryParam(name = "max", required = true)
+    ])
+    def list() {}
+}

--- a/grails-app/controllers/sample/PodController.groovy
+++ b/grails-app/controllers/sample/PodController.groovy
@@ -44,4 +44,7 @@ class PodController { // this example simulates a CRUD-ish controller
 
     @UberDocHeader(name = "never_reached")
     def foobar() {}
+
+    @UberDocResource(internalOnly = true)
+    def internalMethod() {}
 }

--- a/grails-app/controllers/sample/UrlMappings.groovy
+++ b/grails-app/controllers/sample/UrlMappings.groovy
@@ -8,10 +8,16 @@ class UrlMappings {
             group("/pods") {
                 "/"(controller: 'pod', action: 'list', method: 'GET')
                 "/"(controller: 'pod', action: 'create', method: 'POST')
+                "/internal"(controller: 'pod', action: 'internalMethod', method: 'GET')
                 "/$id"(controller: 'pod', action: 'get', method: 'GET')
                 "/$id"(controller: 'pod', action: 'update', method: 'PATCH')
                 "/$id"(controller: 'pod', action: 'update', method: 'PUT')
                 "/$id"(controller: 'pod', action: 'delete', method: 'DELETE')
+            }
+
+            group("/internal") {
+                "/"(controller: 'internal', action: 'list', method: 'GET')
+                "/$id"(controller: 'internal', action: 'get', method: 'GET')
             }
         }
 

--- a/grails-app/domain/sample/Internal.groovy
+++ b/grails-app/domain/sample/Internal.groovy
@@ -1,0 +1,9 @@
+package sample
+
+import uberdoc.annotation.UberDocModel
+
+@UberDocModel(internalOnly = true)
+class Internal extends AbstractObject{
+
+    String secretField
+}

--- a/grails-app/domain/sample/Persona.groovy
+++ b/grails-app/domain/sample/Persona.groovy
@@ -2,6 +2,7 @@ package sample
 
 import uberdoc.annotation.UberDocExplicitProperty
 import uberdoc.annotation.UberDocModel
+import uberdoc.annotation.UberDocProperty
 
 @UberDocModel(description = "overriden description for Persona")
 @UberDocExplicitProperty(name = "dateCreated", type = Date)
@@ -10,6 +11,9 @@ class Persona {
     String firstName
     String lastName
     List<String> nickNames
+
+    @UberDocProperty(internalOnly = true)
+    String internalField
 
     static transients = ['fullName']
     static hasMany = [nickNames: String, pods: Pod]

--- a/src/main/groovy/uberdoc/Utils.groovy
+++ b/src/main/groovy/uberdoc/Utils.groovy
@@ -1,0 +1,28 @@
+package uberdoc
+
+import java.lang.annotation.Annotation
+
+class Utils {
+
+    def grailsApplication
+
+    Utils(grailsApplication) {
+        this.grailsApplication = grailsApplication
+    }
+
+    boolean shouldPublish(Annotation a) {
+        if (!a) {
+            return false
+        }
+
+        if (!a.h.memberValues?.internalOnly) {
+            return true
+        }
+
+        if (grailsApplication.config.uberdoc?.publishInternalOnly) {
+            return true
+        }
+
+        return false
+    }
+}

--- a/src/main/groovy/uberdoc/Utils.groovy
+++ b/src/main/groovy/uberdoc/Utils.groovy
@@ -1,7 +1,5 @@
 package uberdoc
 
-import java.lang.annotation.Annotation
-
 class Utils {
 
     def grailsApplication
@@ -10,19 +8,7 @@ class Utils {
         this.grailsApplication = grailsApplication
     }
 
-    boolean shouldPublish(Annotation a) {
-        if (!a) {
-            return false
-        }
-
-        if (!a.h.memberValues?.internalOnly) {
-            return true
-        }
-
-        if (grailsApplication.config.uberdoc?.publishInternalOnly) {
-            return true
-        }
-
-        return false
+    boolean shouldPublish(a) {
+        return (!a.internalOnly() || grailsApplication.config.uberdoc?.publishInternalOnly)
     }
 }

--- a/src/main/groovy/uberdoc/annotation/UberDocController.groovy
+++ b/src/main/groovy/uberdoc/annotation/UberDocController.groovy
@@ -13,5 +13,8 @@ import java.lang.annotation.Target
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @interface UberDocController {
-
+    /**
+     * Flag indicating that the controller is for internal use only (documentation should not be published to the public docs)
+     */
+    boolean internalOnly() default false
 }

--- a/src/main/groovy/uberdoc/annotation/UberDocModel.groovy
+++ b/src/main/groovy/uberdoc/annotation/UberDocModel.groovy
@@ -19,4 +19,9 @@ import java.lang.annotation.Target
      */
     String description() default ""
 
+    /**
+     * Flag indicating that the model is for internal use only (documentation should not be published to the public docs)
+     */
+    boolean internalOnly() default false
+
 }

--- a/src/main/groovy/uberdoc/annotation/UberDocProperty.groovy
+++ b/src/main/groovy/uberdoc/annotation/UberDocProperty.groovy
@@ -28,4 +28,9 @@ import java.lang.annotation.Target
      * Defines whether the property is mandatory.
      */
     boolean required() default false
+
+    /**
+     * Flag indicating that the controller is for internal use only (documentation should not be published to the public docs)
+     */
+    boolean internalOnly() default false
 }

--- a/src/main/groovy/uberdoc/annotation/UberDocResource.groovy
+++ b/src/main/groovy/uberdoc/annotation/UberDocResource.groovy
@@ -50,4 +50,9 @@ import java.lang.annotation.Target
      */
     Class object() default {} // if requestObject and responseObject are the same, just use this attribute as a shortcut
 
+    /**
+     * Flag indicating that the resource is for internal use only (documentation should not be published to the public docs)
+     */
+    boolean internalOnly() default false
+
 }

--- a/src/main/groovy/uberdoc/metadata/MethodReader.groovy
+++ b/src/main/groovy/uberdoc/metadata/MethodReader.groovy
@@ -107,6 +107,11 @@ class MethodReader {
         return (uberDocResource?.requestIsCollection())
     }
 
+    boolean isInternalOnly() {
+        UberDocResource uberDocResource = reader.getAnnotation(UberDocResource).inMethod(method)
+        return (uberDocResource?.internalOnly())
+    }
+
     List<Map> getErrors() {
         def ret = []
         def methodErrors = reader.getAnnotation(UberDocErrors).inMethod(method)

--- a/src/main/groovy/uberdoc/metadata/RequestAndResponseObjects.groovy
+++ b/src/main/groovy/uberdoc/metadata/RequestAndResponseObjects.groovy
@@ -3,6 +3,7 @@ package uberdoc.metadata
 import grails.core.GrailsApplication
 import grails.core.GrailsDomainClass
 import groovy.util.logging.Log4j
+import uberdoc.Utils
 import uberdoc.annotation.*
 import uberdoc.messages.MessageFallback
 import uberdoc.messages.MessageReader
@@ -21,11 +22,13 @@ class RequestAndResponseObjects {
     private GrailsApplication grailsApplication
     private MessageReader messageReader
     private MessageFallback fallback
+    Utils utils
 
     RequestAndResponseObjects(GrailsApplication g, messageSource, Locale locale) {
         grailsApplication = g
         messageReader = new MessageReader(messageSource, locale)
         fallback = new MessageFallback(messageReader)
+        this.utils = new Utils(grailsApplication)
     }
 
     void extractObjectsInfoFromResource(UberDocResource uberDocResource) {
@@ -161,6 +164,10 @@ class RequestAndResponseObjects {
 
     private Map getProperties(Field field, classConstraints, String objectName) {
         UberDocProperty propertyAnnotation = field.getAnnotation(UberDocProperty)
+
+        if (!utils.shouldPublish(propertyAnnotation)) {
+            return [:]
+        }
 
         // grab info from annotation
         def constraints = []

--- a/src/main/groovy/uberdoc/parser/UberDocResourceParser.groovy
+++ b/src/main/groovy/uberdoc/parser/UberDocResourceParser.groovy
@@ -32,6 +32,7 @@ class UberDocResourceParser {
          bodyParams        : methodReader.bodyParams,
          headers           : methodReader.headers,
          errors            : methodReader.errors,
-         examples          : methodReader.examples]
+         examples          : methodReader.examples,
+         internalOnly      : methodReader.isInternalOnly()]
     }
 }


### PR DESCRIPTION
UB-22515
This PR adds support for internal only documentation to the following annotations:
- @UberDocController
- @UberDocModel
- @UberDocProperty
- @UberDocResource

Internal only documentation can be published by setting `uberdoc.publishInternalOnly` to `true`, which can be used to publish to specific environments.