### PR TITLE
Adds examples support

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,43 @@ Again, resources descriptions will be retrieved from regular message bundles, us
 
 Just annotate the proper classes / methods, inject UberDocService and play around with getApiDocs. All of the rest (caching, UI) can be implemented in the way that fits you best :)
 
+##### @UberDocExample:
+Attaches examples from a json file to the method.
+
+Usage: 
+
+```
+@UberDocExample(file = <filename>)
+```
+where `filename` is the name of a json file under the `resources` directory.`
+
+Example json:
+
+```
+{
+   "examples":
+   [
+      {
+         "name": "Some example",
+         "query_params": {
+            "lang": "en",
+            "version": "20181010"
+         },
+         "body": {
+            "businessId": 123,
+            "locationId": 456
+         },
+         "response": {
+            "statusCode": 200,
+            "output": {
+               "message": "Example message"
+            }
+         }
+      }
+   ]
+}
+```
+
 
 ## Example usages
 

--- a/grails-app/controllers/sample/ApiSomethingElseController.groovy
+++ b/grails-app/controllers/sample/ApiSomethingElseController.groovy
@@ -29,6 +29,7 @@ class ApiSomethingElseController {
             @UberDocUriParam(name = "secondId")
     ])
     @UberDocUriParam(name = "thirdId")
+    @UberDocExample(file = "ApiSomethingElseController_create.json")
     def create() {}
 
     @UberDocResource(object = Pod)

--- a/src/integration-test/groovy/uberdoc/UberDocServiceIntegrationSpec.groovy
+++ b/src/integration-test/groovy/uberdoc/UberDocServiceIntegrationSpec.groovy
@@ -42,6 +42,26 @@ class UberDocServiceIntegrationSpec extends Specification {
         1 == somethingElse.headers.size()
         0 == somethingElse.queryParams.size()
         3 == somethingElse.uriParams.size()
+        somethingElse.examples as String == [
+                examples: [
+                        [
+                                body        : [
+                                        businessId: 123,
+                                        locationId: 456],
+                                name        : "Some example",
+                                query_params: [
+                                        lang   : "en",
+                                        version: 20181010
+                                ],
+                                response    : [
+                                        output    : [
+                                                message: "Example message"
+                                        ],
+                                        statusCode: 200
+                                ]
+                        ]
+                ]
+        ] as String
 
         podsIdGet
         "GET" == podsIdGet.method

--- a/src/main/groovy/uberdoc/annotation/UberDocExample.groovy
+++ b/src/main/groovy/uberdoc/annotation/UberDocExample.groovy
@@ -1,0 +1,19 @@
+package uberdoc.annotation
+
+import java.lang.annotation.ElementType
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+import java.lang.annotation.Target
+
+/**
+ * Provides example information as to the use and response of an action.
+ */
+@Target([ElementType.METHOD, ElementType.TYPE])
+@Retention(RetentionPolicy.RUNTIME)
+@interface UberDocExample {
+    /**
+     * The .json file containing the example(s)
+     * @return
+     */
+    String file() default ""
+}

--- a/src/main/groovy/uberdoc/metadata/MethodReader.groovy
+++ b/src/main/groovy/uberdoc/metadata/MethodReader.groovy
@@ -1,5 +1,7 @@
 package uberdoc.metadata
 
+import groovy.json.JsonException
+import groovy.json.JsonSlurper
 import uberdoc.annotation.*
 import uberdoc.messages.MessageFallback
 import uberdoc.messages.MessageReader
@@ -121,6 +123,17 @@ class MethodReader {
         }
 
         return ret
+    }
+
+    Object getExamples() {
+        UberDocExample examples = reader.getAnnotation(UberDocExample).inMethod(method) as UberDocExample
+
+        if (!examples || !examples.file()) {
+            return null
+        }
+
+        JsonSlurper jsonSlurper = new JsonSlurper()
+        return jsonSlurper.parse(this.class.classLoader.getResource(examples.file()) as URL)
     }
 
     private Map parseError(err) {

--- a/src/main/groovy/uberdoc/parser/UberDocResourceParser.groovy
+++ b/src/main/groovy/uberdoc/parser/UberDocResourceParser.groovy
@@ -31,6 +31,7 @@ class UberDocResourceParser {
          queryParams       : methodReader.queryParams,
          bodyParams        : methodReader.bodyParams,
          headers           : methodReader.headers,
-         errors            : methodReader.errors]
+         errors            : methodReader.errors,
+         examples          : methodReader.examples]
     }
 }

--- a/src/main/resources/ApiSomethingElseController_create.json
+++ b/src/main/resources/ApiSomethingElseController_create.json
@@ -1,0 +1,22 @@
+{
+   "examples":
+   [
+      {
+         "name": "Some example",
+         "query_params": {
+            "lang": "en",
+            "version": "20181010"
+         },
+         "body": {
+            "businessId": 123,
+            "locationId": 456
+         },
+         "response": {
+            "statusCode": 200,
+            "output": {
+               "message": "Example message"
+            }
+         }
+      }
+   ]
+}


### PR DESCRIPTION
Adds the new annotation `@UberDocExample` which expects the filename as string and attaches the parsed result to the method response.