### PR TITLE
Introduced sorting, removed caching and support for different Locales

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,20 @@
 
 A very simple Grails plugin to generate RESTful API documentation.
 
+*Find older readme files [here](/readme_files)*
+
 This plug-in is meant to provide a very simple way to extract RESTful information from Grails apps.
 
 What it does is going through all controllers annotated with @UberDocController and extract information from request/response objects, along with information from UrlMappings
-and structure it within a Map, that then can be used whatever way the app using it feels like is more appropriate.
+and structure it within an ApiDocumentation object, that then can be used whatever way the app using it feels like is more appropriate.
 
-So, the plugin just provides:
+So, the plugin provides:
 - a set of annotations
-- a Service with a public method that extracts information from classes and return it as a Map
-
-This was done on purpose, so that your app can decide on the best way to display or cache this information.
+- a Service with a public method that extracts information from classes and return it as an ApiDocumentation object
+- ApiDocumentation object which contains following properties
+-- objects (Map): 
+-- resources (List<Map>)
+-- resourcesByObjects(List<Map.Entry>)
 
 ## Installation
 
@@ -26,7 +30,7 @@ repositories {
 
 dependencies {
     ...
-    compile 'org.grails.plugins:uber-doc:3.0.1'
+    compile 'org.grails.plugins:uber-doc:3.2'
     ...
 }
 ```
@@ -41,11 +45,15 @@ As previously stated, this plugin offers a Service class (UberDocService) with a
 -- retrieve all mappings associated with this controller in UrlMappings
 -- retrieve all methods from that controller annotated with @UberDocResource
 -- combine the information extracted from UrlMappings with the information extracted from both controller and methods annotation to build a block of meta information about both the resource served by that method and the objects used in request and response messages.
+- creates new ApiDocumentation object and sort it by following before returning it
+-- objects: all objects will be sorted (asc) by their 'name', while for each object the 'properties" will also be sorted (asc) by their name
+-- resources: for each resources Map the following fields will be sorted (asc) by their name, 'queryParams', 'uriParams' and 'bodyParams'
+-- resources itself will be sorted (asc) by their 'uri' and 'method' where method will be replaced with their associated orderingNumber (GET:0, POST:1, PUT:2, PATCH:3, DELETE:4, default:99)
 
 Examples of information about API resources that are returned by this method:
 
-- resources URI's (e.g.: /api/spaceships/)
-- supported methods (e.g.: /api/spaceships/ supports GET and POST)
+- resources URI's (e.g.: /api/spaceships)
+- supported methods (e.g.: /api/spaceships supports GET and POST)
 - description of a resource
 - headers to be used when interacting with a resource
 - errors to expect when interacting with a resource
@@ -131,143 +139,17 @@ You can find examples of the plugin usage within the source code itself, under t
 https://github.com/uberall/grails-uber-doc/tree/master/grails-app/controllers/sample
 https://github.com/uberall/grails-uber-doc/tree/master/grails-app/domain/sample
 
-Once the annotations have been added to your code, a call to `UberDocService#getApiDocs` will return a Map structured around two main concepts: 
+Once the annotations have been added to your code, a call to `UberDocService#getApiDocs` will return an ApiDocumentation object with the following three properties: 
 
 * `resources`: contains information about the resources supported by your app. These information include supported HTTP methods (derived from `UrlMappings.groovy`), supported headers, possible errors (derived from the annotations you put on your controllers).
+* `resourcesByObjects`: collected resource information grouped by their URI name (e.g. [["key": "pods", "value": [...]], ["key": "Spaceship", "value": [...]]])
 * `objects`: holds information about the objects your app uses for transiting information. This derives from the annotations you put on your controllers and annotations put on your domain / POGO classes. That includes attributes contained on each object, their types (`String`, `Long`, etc) and constraints (e.g.: `maxSize: 20`, `nullable: false`), among other things.
 
-For example, if you run the integration test provided with the plugin, `UberDocService#getApiDocs` will return a map structured as follows (using JSON representation):
+For example, if you run the integration test provided with the plugin, `UberDocService#getApiDocs` will return an ApiDocumentation object as the following (using JSON representation):
 
 ```
 {
     "resources": [
-        {
-            "baseMessageKey": "uberDoc.resource.api.something.else.POST",
-            "title": "uberDoc.api.something.else.POST.title",
-            "description": "uberDoc.resource.api.something.else.POST.description",
-            "uri": "/api/something/else",
-            "method": "POST",
-            "requestObject": "Pod",
-            "requestCollection": false,
-            "responseObject": "Pod",
-            "responseCollection": false,
-            "uriParams": [
-                {
-                    "name": "thirdId",
-                    "description": "uberDoc.resource.api.something.else.POST.uriParam.thirdId.description",
-                    "sampleValue": "uberDoc.resource.api.something.else.POST.uriParam.thirdId.sampleValue"
-                },
-                {
-                    "name": "firstId",
-                    "description": "uberDoc.resource.api.something.else.POST.uriParam.firstId.description",
-                    "sampleValue": "uberDoc.resource.api.something.else.POST.uriParam.firstId.sampleValue"
-                },
-                {
-                    "name": "secondId",
-                    "description": "uberDoc.resource.api.something.else.POST.uriParam.secondId.description",
-                    "sampleValue": "uberDoc.resource.api.something.else.POST.uriParam.secondId.sampleValue"
-                }
-            ],
-            "queryParams": [],
-            "bodyParams": [],
-            "headers": [
-                {
-                    "name": "some header param",
-                    "description": "uberDoc.resource.api.something.else.POST.header.some.header.param.description",
-                    "sampleValue": "uberDoc.resource.api.something.else.POST.header.some.header.param.sampleValue",
-                    "required": false
-                }
-            ],
-            "errors": []
-        },
-        {
-            "baseMessageKey": "uberDoc.resource.api.pods.$id.GET",
-            "title": "uberDoc.api.pods.$id.GET.title",
-            "description": "uberDoc.resource.api.pods.$id.GET.description",
-            "uri": "/api/pods/$id",
-            "method": "GET",
-            "requestObject": null,
-            "requestCollection": false,
-            "responseObject": "Pod",
-            "responseCollection": true,
-            "uriParams": [
-                {
-                    "name": "id",
-                    "description": "uberDoc.resource.api.pods.$id.GET.uriParam.id.description",
-                    "sampleValue": "uberDoc.resource.api.pods.$id.GET.uriParam.id.sampleValue"
-                }
-            ],
-            "queryParams": [],
-            "bodyParams": [],
-            "headers": [],
-            "errors": [
-                {
-                    "errorCode": "NF404",
-                    "httpCode": 404,
-                    "description": "uberDoc.resource.api.pods.$id.GET.error.404.description"
-                }
-            ]
-        },
-        {
-            "baseMessageKey": "uberDoc.resource.api.pods.POST",
-            "title": "uberDoc.api.pods.POST.title",
-            "description": "uberDoc.resource.api.pods.POST.description",
-            "uri": "/api/pods",
-            "method": "POST",
-            "requestObject": "Pod",
-            "requestCollection": false,
-            "responseObject": "Pod",
-            "responseCollection": false,
-            "uriParams": [
-                {
-                    "name": "thirdId",
-                    "description": "uberDoc.resource.api.pods.POST.uriParam.thirdId.description",
-                    "sampleValue": "uberDoc.resource.api.pods.POST.uriParam.thirdId.sampleValue"
-                },
-                {
-                    "name": "firstId",
-                    "description": "uberDoc.resource.api.pods.POST.uriParam.firstId.description",
-                    "sampleValue": "uberDoc.resource.api.pods.POST.uriParam.firstId.sampleValue"
-                },
-                {
-                    "name": "secondId",
-                    "description": "uberDoc.resource.api.pods.POST.uriParam.secondId.description",
-                    "sampleValue": "uberDoc.resource.api.pods.POST.uriParam.secondId.sampleValue"
-                }
-            ],
-            "queryParams": [],
-            "bodyParams": [
-                {
-                    "name": "firstBody",
-                    "description": "uberDoc.resource.api.pods.POST.bodyParam.firstBody.description",
-                    "sampleValue": "uberDoc.resource.api.pods.POST.bodyParam.firstBody.sampleValue",
-                    "type": "Long",
-                    "required": true
-                },
-                {
-                    "name": "secondBody",
-                    "description": "2nd body desc",
-                    "sampleValue": "body",
-                    "type": "String",
-                    "required": false
-                }
-            ],
-            "headers": [
-                {
-                    "name": "some header param",
-                    "description": "my header",
-                    "sampleValue": "my sample value",
-                    "required": false
-                }
-            ],
-            "errors": [
-                {
-                    "errorCode": "NF404",
-                    "httpCode": 404,
-                    "description": "my sample error"
-                }
-            ]
-        },
         {
             "baseMessageKey": "uberDoc.resource.api.pods.GET",
             "title": "custom title for list resource",
@@ -302,29 +184,101 @@ For example, if you run the integration test provided with the plugin, `UberDocS
                     "required": false
                 }
             ],
-            "errors": []
+            "errors": [],
+            "examples": null,
+            "internalOnly": false
         },
         {
-            "baseMessageKey": "uberDoc.resource.api.pods.$id.DELETE",
-            "title": "uberDoc.api.pods.$id.DELETE.title",
-            "description": "uberDoc.resource.api.pods.$id.DELETE.description",
-            "uri": "/api/pods/$id",
-            "method": "DELETE",
-            "requestObject": null,
+            "baseMessageKey": "uberDoc.resource.api.pods.POST",
+            "title": "uberDoc.api.pods.POST.title",
+            "description": "uberDoc.resource.api.pods.POST.description",
+            "uri": "/api/pods",
+            "method": "POST",
+            "requestObject": "Pod",
             "requestCollection": false,
-            "responseObject": null,
+            "responseObject": "Pod",
             "responseCollection": false,
             "uriParams": [
                 {
+                    "name": "firstId",
+                    "description": "uberDoc.resource.api.pods.POST.uriParam.firstId.description",
+                    "sampleValue": "uberDoc.resource.api.pods.POST.uriParam.firstId.sampleValue"
+                },
+                {
+                    "name": "secondId",
+                    "description": "uberDoc.resource.api.pods.POST.uriParam.secondId.description",
+                    "sampleValue": "uberDoc.resource.api.pods.POST.uriParam.secondId.sampleValue"
+                },
+                {
+                    "name": "thirdId",
+                    "description": "uberDoc.resource.api.pods.POST.uriParam.thirdId.description",
+                    "sampleValue": "uberDoc.resource.api.pods.POST.uriParam.thirdId.sampleValue"
+                }
+            ],
+            "queryParams": [],
+            "bodyParams": [
+                {
+                    "name": "firstBody",
+                    "description": "uberDoc.resource.api.pods.POST.bodyParam.firstBody.description",
+                    "sampleValue": "uberDoc.resource.api.pods.POST.bodyParam.firstBody.sampleValue",
+                    "type": "Long",
+                    "required": true
+                },
+                {
+                    "name": "secondBody",
+                    "description": "2nd body desc",
+                    "sampleValue": "body",
+                    "type": "String",
+                    "required": false
+                }
+            ],
+            "headers": [
+                {
+                    "name": "some header param",
+                    "description": "my header",
+                    "sampleValue": "my sample value",
+                    "required": false
+                }
+            ],
+            "errors": [
+                {
+                    "errorCode": "NF404",
+                    "httpCode": 404,
+                    "description": "my sample error"
+                }
+            ],
+            "examples": null,
+            "internalOnly": false
+        },
+        {
+            "baseMessageKey": "uberDoc.resource.api.pods.$id.GET",
+            "title": "uberDoc.api.pods.$id.GET.title",
+            "description": "uberDoc.resource.api.pods.$id.GET.description",
+            "uri": "/api/pods/$id",
+            "method": "GET",
+            "requestObject": null,
+            "requestCollection": false,
+            "responseObject": "Pod",
+            "responseCollection": true,
+            "uriParams": [
+                {
                     "name": "id",
-                    "description": "uberDoc.resource.api.pods.$id.DELETE.uriParam.id.description",
-                    "sampleValue": "uberDoc.resource.api.pods.$id.DELETE.uriParam.id.sampleValue"
+                    "description": "uberDoc.resource.api.pods.$id.GET.uriParam.id.description",
+                    "sampleValue": "uberDoc.resource.api.pods.$id.GET.uriParam.id.sampleValue"
                 }
             ],
             "queryParams": [],
             "bodyParams": [],
             "headers": [],
-            "errors": []
+            "errors": [
+                {
+                    "errorCode": "NF404",
+                    "httpCode": 404,
+                    "description": "uberDoc.resource.api.pods.$id.GET.error.404.description"
+                }
+            ],
+            "examples": null,
+            "internalOnly": false
         },
         {
             "baseMessageKey": "uberDoc.resource.api.pods.$id.PUT",
@@ -360,44 +314,380 @@ For example, if you run the integration test provided with the plugin, `UberDocS
                     "required": false
                 }
             ],
-            "errors": []
+            "errors": [],
+            "examples": null,
+            "internalOnly": false
+        },
+        {
+            "baseMessageKey": "uberDoc.resource.api.pods.$id.DELETE",
+            "title": "uberDoc.api.pods.$id.DELETE.title",
+            "description": "uberDoc.resource.api.pods.$id.DELETE.description",
+            "uri": "/api/pods/$id",
+            "method": "DELETE",
+            "requestObject": null,
+            "requestCollection": false,
+            "responseObject": null,
+            "responseCollection": false,
+            "uriParams": [
+                {
+                    "name": "id",
+                    "description": "uberDoc.resource.api.pods.$id.DELETE.uriParam.id.description",
+                    "sampleValue": "uberDoc.resource.api.pods.$id.DELETE.uriParam.id.sampleValue"
+                }
+            ],
+            "queryParams": [],
+            "bodyParams": [],
+            "headers": [],
+            "errors": [],
+            "examples": null,
+            "internalOnly": false
+        },
+        {
+            "baseMessageKey": "uberDoc.resource.api.something.else.POST",
+            "title": "uberDoc.api.something.else.POST.title",
+            "description": "uberDoc.resource.api.something.else.POST.description",
+            "uri": "/api/something/else",
+            "method": "POST",
+            "requestObject": "Pod",
+            "requestCollection": false,
+            "responseObject": "Pod",
+            "responseCollection": false,
+            "uriParams": [
+                {
+                    "name": "firstId",
+                    "description": "uberDoc.resource.api.something.else.POST.uriParam.firstId.description",
+                    "sampleValue": "uberDoc.resource.api.something.else.POST.uriParam.firstId.sampleValue"
+                },
+                {
+                    "name": "secondId",
+                    "description": "uberDoc.resource.api.something.else.POST.uriParam.secondId.description",
+                    "sampleValue": "uberDoc.resource.api.something.else.POST.uriParam.secondId.sampleValue"
+                },
+                {
+                    "name": "thirdId",
+                    "description": "uberDoc.resource.api.something.else.POST.uriParam.thirdId.description",
+                    "sampleValue": "uberDoc.resource.api.something.else.POST.uriParam.thirdId.sampleValue"
+                }
+            ],
+            "queryParams": [],
+            "bodyParams": [],
+            "headers": [
+                {
+                    "name": "some header param",
+                    "description": "uberDoc.resource.api.something.else.POST.header.some.header.param.description",
+                    "sampleValue": "uberDoc.resource.api.something.else.POST.header.some.header.param.sampleValue",
+                    "required": false
+                }
+            ],
+            "errors": [],
+            "examples": {
+                "examples": [
+                    {
+                        "name": "Some example",
+                        "query_params": {
+                            "lang": "en",
+                            "version": "20181010"
+                        },
+                        "body": {
+                            "businessId": 123,
+                            "locationId": 456
+                        },
+                        "response": {
+                            "statusCode": 200,
+                            "output": {
+                                "message": "Example message"
+                            }
+                        }
+                    }
+                ]
+            },
+            "internalOnly": false
+        }
+    ],
+    "resourcesByObjects": [
+        {
+            "key": "pods",
+            "value": [
+                {
+                    "baseMessageKey": "uberDoc.resource.api.pods.GET",
+                    "title": "custom title for list resource",
+                    "description": "custom description for list resource",
+                    "uri": "/api/pods",
+                    "method": "GET",
+                    "requestObject": null,
+                    "requestCollection": false,
+                    "responseObject": "Pod",
+                    "responseCollection": true,
+                    "uriParams": [],
+                    "queryParams": [
+                        {
+                            "name": "max",
+                            "description": "uberDoc.resource.api.pods.GET.queryParam.max.description",
+                            "sampleValue": "uberDoc.resource.api.pods.GET.queryParam.max.sampleValue",
+                            "required": true
+                        },
+                        {
+                            "name": "page",
+                            "description": "custom description",
+                            "sampleValue": "custom value",
+                            "required": false
+                        }
+                    ],
+                    "bodyParams": [],
+                    "headers": [
+                        {
+                            "name": "hdr",
+                            "description": "uberDoc.resource.api.pods.GET.header.hdr.description",
+                            "sampleValue": "uberDoc.resource.api.pods.GET.header.hdr.sampleValue",
+                            "required": false
+                        }
+                    ],
+                    "errors": [],
+                    "examples": null,
+                    "internalOnly": false
+                },
+                {
+                    "baseMessageKey": "uberDoc.resource.api.pods.POST",
+                    "title": "uberDoc.api.pods.POST.title",
+                    "description": "uberDoc.resource.api.pods.POST.description",
+                    "uri": "/api/pods",
+                    "method": "POST",
+                    "requestObject": "Pod",
+                    "requestCollection": false,
+                    "responseObject": "Pod",
+                    "responseCollection": false,
+                    "uriParams": [
+                        {
+                            "name": "firstId",
+                            "description": "uberDoc.resource.api.pods.POST.uriParam.firstId.description",
+                            "sampleValue": "uberDoc.resource.api.pods.POST.uriParam.firstId.sampleValue"
+                        },
+                        {
+                            "name": "secondId",
+                            "description": "uberDoc.resource.api.pods.POST.uriParam.secondId.description",
+                            "sampleValue": "uberDoc.resource.api.pods.POST.uriParam.secondId.sampleValue"
+                        },
+                        {
+                            "name": "thirdId",
+                            "description": "uberDoc.resource.api.pods.POST.uriParam.thirdId.description",
+                            "sampleValue": "uberDoc.resource.api.pods.POST.uriParam.thirdId.sampleValue"
+                        }
+                    ],
+                    "queryParams": [],
+                    "bodyParams": [
+                        {
+                            "name": "firstBody",
+                            "description": "uberDoc.resource.api.pods.POST.bodyParam.firstBody.description",
+                            "sampleValue": "uberDoc.resource.api.pods.POST.bodyParam.firstBody.sampleValue",
+                            "type": "Long",
+                            "required": true
+                        },
+                        {
+                            "name": "secondBody",
+                            "description": "2nd body desc",
+                            "sampleValue": "body",
+                            "type": "String",
+                            "required": false
+                        }
+                    ],
+                    "headers": [
+                        {
+                            "name": "some header param",
+                            "description": "my header",
+                            "sampleValue": "my sample value",
+                            "required": false
+                        }
+                    ],
+                    "errors": [
+                        {
+                            "errorCode": "NF404",
+                            "httpCode": 404,
+                            "description": "my sample error"
+                        }
+                    ],
+                    "examples": null,
+                    "internalOnly": false
+                },
+                {
+                    "baseMessageKey": "uberDoc.resource.api.pods.$id.GET",
+                    "title": "uberDoc.api.pods.$id.GET.title",
+                    "description": "uberDoc.resource.api.pods.$id.GET.description",
+                    "uri": "/api/pods/$id",
+                    "method": "GET",
+                    "requestObject": null,
+                    "requestCollection": false,
+                    "responseObject": "Pod",
+                    "responseCollection": true,
+                    "uriParams": [
+                        {
+                            "name": "id",
+                            "description": "uberDoc.resource.api.pods.$id.GET.uriParam.id.description",
+                            "sampleValue": "uberDoc.resource.api.pods.$id.GET.uriParam.id.sampleValue"
+                        }
+                    ],
+                    "queryParams": [],
+                    "bodyParams": [],
+                    "headers": [],
+                    "errors": [
+                        {
+                            "errorCode": "NF404",
+                            "httpCode": 404,
+                            "description": "uberDoc.resource.api.pods.$id.GET.error.404.description"
+                        }
+                    ],
+                    "examples": null,
+                    "internalOnly": false
+                },
+                {
+                    "baseMessageKey": "uberDoc.resource.api.pods.$id.PUT",
+                    "title": "uberDoc.api.pods.$id.PUT.title",
+                    "description": "uberDoc.resource.api.pods.$id.PUT.description",
+                    "uri": "/api/pods/$id",
+                    "method": "PUT",
+                    "requestObject": "Pod",
+                    "requestCollection": false,
+                    "responseObject": "Pod",
+                    "responseCollection": false,
+                    "uriParams": [
+                        {
+                            "name": "id",
+                            "description": "custom description for id",
+                            "sampleValue": "custom sample value for id"
+                        }
+                    ],
+                    "queryParams": [
+                        {
+                            "name": "foobar",
+                            "description": "uberDoc.resource.api.pods.$id.PUT.queryParam.foobar.description",
+                            "sampleValue": "uberDoc.resource.api.pods.$id.PUT.queryParam.foobar.sampleValue",
+                            "required": false
+                        }
+                    ],
+                    "bodyParams": [],
+                    "headers": [
+                        {
+                            "name": "hdr",
+                            "description": "uberDoc.resource.api.pods.$id.PUT.header.hdr.description",
+                            "sampleValue": "uberDoc.resource.api.pods.$id.PUT.header.hdr.sampleValue",
+                            "required": false
+                        }
+                    ],
+                    "errors": [],
+                    "examples": null,
+                    "internalOnly": false
+                },
+                {
+                    "baseMessageKey": "uberDoc.resource.api.pods.$id.DELETE",
+                    "title": "uberDoc.api.pods.$id.DELETE.title",
+                    "description": "uberDoc.resource.api.pods.$id.DELETE.description",
+                    "uri": "/api/pods/$id",
+                    "method": "DELETE",
+                    "requestObject": null,
+                    "requestCollection": false,
+                    "responseObject": null,
+                    "responseCollection": false,
+                    "uriParams": [
+                        {
+                            "name": "id",
+                            "description": "uberDoc.resource.api.pods.$id.DELETE.uriParam.id.description",
+                            "sampleValue": "uberDoc.resource.api.pods.$id.DELETE.uriParam.id.sampleValue"
+                        }
+                    ],
+                    "queryParams": [],
+                    "bodyParams": [],
+                    "headers": [],
+                    "errors": [],
+                    "examples": null,
+                    "internalOnly": false
+                }
+            ]
+        },
+        {
+            "key": "something",
+            "value": [
+                {
+                    "baseMessageKey": "uberDoc.resource.api.something.else.POST",
+                    "title": "uberDoc.api.something.else.POST.title",
+                    "description": "uberDoc.resource.api.something.else.POST.description",
+                    "uri": "/api/something/else",
+                    "method": "POST",
+                    "requestObject": "Pod",
+                    "requestCollection": false,
+                    "responseObject": "Pod",
+                    "responseCollection": false,
+                    "uriParams": [
+                        {
+                            "name": "firstId",
+                            "description": "uberDoc.resource.api.something.else.POST.uriParam.firstId.description",
+                            "sampleValue": "uberDoc.resource.api.something.else.POST.uriParam.firstId.sampleValue"
+                        },
+                        {
+                            "name": "secondId",
+                            "description": "uberDoc.resource.api.something.else.POST.uriParam.secondId.description",
+                            "sampleValue": "uberDoc.resource.api.something.else.POST.uriParam.secondId.sampleValue"
+                        },
+                        {
+                            "name": "thirdId",
+                            "description": "uberDoc.resource.api.something.else.POST.uriParam.thirdId.description",
+                            "sampleValue": "uberDoc.resource.api.something.else.POST.uriParam.thirdId.sampleValue"
+                        }
+                    ],
+                    "queryParams": [],
+                    "bodyParams": [],
+                    "headers": [
+                        {
+                            "name": "some header param",
+                            "description": "uberDoc.resource.api.something.else.POST.header.some.header.param.description",
+                            "sampleValue": "uberDoc.resource.api.something.else.POST.header.some.header.param.sampleValue",
+                            "required": false
+                        }
+                    ],
+                    "errors": [],
+                    "examples": {
+                        "examples": [
+                            {
+                                "name": "Some example",
+                                "query_params": {
+                                    "lang": "en",
+                                    "version": "20181010"
+                                },
+                                "body": {
+                                    "businessId": 123,
+                                    "locationId": 456
+                                },
+                                "response": {
+                                    "statusCode": 200,
+                                    "output": {
+                                        "message": "Example message"
+                                    }
+                                }
+                            }
+                        ]
+                    },
+                    "internalOnly": false
+                }
+            ]
         }
     ],
     "objects": {
+        "Persona": {
+            "name": "Persona",
+            "description": "overriden description for Persona",
+            "properties": [
+                {
+                    "name": "dateCreated",
+                    "type": "Date",
+                    "description": "uberDoc.object.Persona.dateCreated.description",
+                    "sampleValue": "uberDoc.object.Persona.dateCreated.sampleValue",
+                    "required": false,
+                    "isCollection": false
+                }
+            ]
+        },
         "Pod": {
             "name": "Pod",
             "description": "overriden description for model",
             "properties": [
-                {
-                    "name": "shared",
-                    "description": "uberDoc.object.Pod.shared.description",
-                    "sampleValue": "uberDoc.object.Pod.shared.sampleValue",
-                    "required": false,
-                    "type": "String",
-                    "constraints": [
-                        {
-                            "constraint": "nullable",
-                            "value": false
-                        }
-                    ]
-                },
-                {
-                    "name": "license",
-                    "description": "uberDoc.object.Pod.license.description",
-                    "sampleValue": "uberDoc.object.Pod.license.sampleValue",
-                    "required": true,
-                    "type": "String",
-                    "constraints": [
-                        {
-                            "constraint": "blank",
-                            "value": true
-                        },
-                        {
-                            "constraint": "nullable",
-                            "value": false
-                        }
-                    ]
-                },
                 {
                     "name": "botName",
                     "description": "botName has a description",
@@ -420,21 +710,97 @@ For example, if you run the integration test provided with the plugin, `UberDocS
                     "type": "Date",
                     "description": "uberDoc.object.Pod.dateCreated.description",
                     "sampleValue": "uberDoc.object.Pod.dateCreated.sampleValue",
-                    "required": false
-                },
-                {
-                    "name": "inherited",
-                    "type": "String",
-                    "description": "uberDoc.object.Pod.inherited.description",
-                    "sampleValue": "uberDoc.object.Pod.inherited.sampleValue",
-                    "required": false
+                    "required": false,
+                    "isCollection": false
                 },
                 {
                     "name": "id",
                     "type": "Long",
                     "description": "uberDoc.object.Pod.id.description",
                     "sampleValue": "uberDoc.object.Pod.id.sampleValue",
-                    "required": false
+                    "required": false,
+                    "isCollection": false
+                },
+                {
+                    "name": "inherited",
+                    "type": "String",
+                    "description": "uberDoc.object.Pod.inherited.description",
+                    "sampleValue": "uberDoc.object.Pod.inherited.sampleValue",
+                    "required": false,
+                    "isCollection": false
+                },
+                {
+                    "name": "license",
+                    "description": "uberDoc.object.Pod.license.description",
+                    "sampleValue": "uberDoc.object.Pod.license.sampleValue",
+                    "required": true,
+                    "type": "String",
+                    "constraints": [
+                        {
+                            "constraint": "blank",
+                            "value": true
+                        },
+                        {
+                            "constraint": "nullable",
+                            "value": false
+                        }
+                    ]
+                },
+                {
+                    "name": "longCollection",
+                    "type": "Long",
+                    "description": "uberDoc.object.Pod.longCollection.description",
+                    "sampleValue": "uberDoc.object.Pod.longCollection.sampleValue",
+                    "required": false,
+                    "isCollection": true
+                },
+                {
+                    "name": "persons",
+                    "description": "uberDoc.object.Pod.persons.description",
+                    "sampleValue": "uberDoc.object.Pod.persons.sampleValue",
+                    "required": false,
+                    "type": "Map",
+                    "constraints": [
+                        {
+                            "constraint": "nullable",
+                            "value": true
+                        }
+                    ]
+                },
+                {
+                    "name": "shared",
+                    "description": "uberDoc.object.Pod.shared.description",
+                    "sampleValue": "uberDoc.object.Pod.shared.sampleValue",
+                    "required": false,
+                    "type": "String",
+                    "constraints": [
+                        {
+                            "constraint": "nullable",
+                            "value": false
+                        }
+                    ]
+                },
+                {
+                    "name": "spaceship",
+                    "type": "Spaceship",
+                    "description": "uberDoc.object.Pod.spaceship.description",
+                    "sampleValue": "uberDoc.object.Pod.spaceship.sampleValue",
+                    "required": false,
+                    "isCollection": false
+                }
+            ]
+        },
+        "Spaceship": {
+            "name": "Spaceship",
+            "description": "overriden description for Spaceship",
+            "properties": [
+                {
+                    "name": "dateCreated",
+                    "type": "Date",
+                    "description": "uberDoc.object.Spaceship.dateCreated.description",
+                    "sampleValue": "uberDoc.object.Spaceship.dateCreated.sampleValue",
+                    "required": false,
+                    "isCollection": false
                 }
             ]
         }

--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,7 @@ dependencies {
     provided "org.grails:grails-plugin-services"
     provided "org.grails:grails-plugin-domain-class"
     testCompile "org.grails:grails-plugin-testing"
+    testCompile "org.grails:grails-test-mixins:3.3.0"
 }
 
 task wrapper(type: Wrapper) {

--- a/readme_files/3_1_1.md
+++ b/readme_files/3_1_1.md
@@ -1,0 +1,457 @@
+# Uber Doc Grails Plugin
+
+A very simple Grails plugin to generate RESTful API documentation.
+
+This plug-in is meant to provide a very simple way to extract RESTful information from Grails apps.
+
+What it does is going through all controllers annotated with @UberDocController and extract information from request/response objects, along with information from UrlMappings
+and structure it within a Map, that then can be used whatever way the app using it feels like is more appropriate.
+
+So, the plugin just provides:
+- a set of annotations
+- a Service with a public method that extracts information from classes and return it as a Map
+
+This was done on purpose, so that your app can decide on the best way to display or cache this information.
+
+## Installation
+
+Edit build.gradle, by adding the following:
+
+```groovy
+repositories {
+    ...
+    maven { url "http://dl.bintray.com/uberall/plugins" }
+    ...
+}
+
+dependencies {
+    ...
+    compile 'org.grails.plugins:uber-doc:3.1.1'
+    ...
+}
+```
+
+## How does it work?
+
+As previously stated, this plugin offers a Service class (UberDocService) with a public method (getApiDocs). When invoked, this method will
+
+- go through every controller
+- skip the ones not annotated with @UberDocController and
+- for each controller that uses @UberDocController, it will
+-- retrieve all mappings associated with this controller in UrlMappings
+-- retrieve all methods from that controller annotated with @UberDocResource
+-- combine the information extracted from UrlMappings with the information extracted from both controller and methods annotation to build a block of meta information about both the resource served by that method and the objects used in request and response messages.
+
+Examples of information about API resources that are returned by this method:
+
+- resources URI's (e.g.: /api/spaceships)
+- supported methods (e.g.: /api/spaceships supports GET and POST)
+- description of a resource
+- headers to be used when interacting with a resource
+- errors to expect when interacting with a resource
+
+Examples of information about request / response objects returned by this method:
+- class name
+- properties names
+- properties types
+- properties constraints (when a request / response object is a domain class or uses @Validateable)
+- sample value for a property
+
+
+## How to use this plugin
+
+This plugin offers basically a set of annotations, along with plural variations of some of them, when applicable:
+
+##### @UberDocController:
+Identifies a controller that defines API resources that should be documented.
+##### @UberDocResource:
+Identifies a controller method (aka resource) to be documented. Within an `UberDocController`. Parameters are `requestObject`, `responseObject`, `requestIsCollection`, and `responseIsCollection`.
+##### @UberDocError(s):
+Provides information about errors a resource can signal to the user. Parameters are `httpCode` and `errorCode`.
+##### @UberDocHeader(s):
+Provides information about headers to be used when interacting with a given resource. Parameters are `name` and `required`.
+##### @UberDocUriParam(s):
+Provides information about URI parameters used by a resource (e.g.: /api/dogs/$id/children/$otherId/). Parameters are `name` and `required`. `name` will be used for displaying about a specific parameter in the URI. Note that this is positional, meaning, an annotation about $id should be used before an annotation about $otherId to be applied to the resource's URI correctly.
+##### @UberDocQueryParam(s):
+Documents information about query parameters used in a resources URL. For instance, it can be used to document pagination parameters within a URL like /api/dogs/?max=10&offset=3. Parameters are `name` and `required`.
+##### @UberDocBodyParam(s):
+Documents information about parameters that have to be sent as part of the body. For instance, it can be used to describe a subset of parameters (excluding auto-generated properties) used to create a response object.
+##### @UberDocModel:
+Describes classes used as request or response objects.
+##### @UberDocProperty:
+Defines information about properties of a given request/response object to be made available in the API documentation. Please specify hasMany collections explicitly as Set<Object> / List<Object> and annotate them.
+##### @UberDocExplicitProperty(ies):
+Allows describing additional properties explicitly. Such could be values calculated for response objects when marshalling JSON responses for them. Parameters are `name` and `type`.
+
+Again, resources descriptions will be retrieved from regular message bundles, using proper locales. The keys are structured with regard to the resources / objects, parameters and http methods, e.g., `uberDoc.resource.your.path.$someId.PATCH.uriParam.someId.name`.
+
+Just annotate the proper classes / methods, inject UberDocService and play around with getApiDocs. All of the rest (caching, UI) can be implemented in the way that fits you best :)
+
+##### @UberDocExample:
+Attaches examples from a json file to the method.
+
+Usage: 
+
+```
+@UberDocExample(file = <filename>)
+```
+where `filename` is the name of a json file under the `resources` directory.`
+
+Example json:
+
+```
+{
+   "examples":
+   [
+      {
+         "name": "Some example",
+         "query_params": {
+            "lang": "en",
+            "version": "20181010"
+         },
+         "body": {
+            "businessId": 123,
+            "locationId": 456
+         },
+         "response": {
+            "statusCode": 200,
+            "output": {
+               "message": "Example message"
+            }
+         }
+      }
+   ]
+}
+```
+
+## Example usages
+
+You can find examples of the plugin usage within the source code itself, under the "sample" package:
+
+https://github.com/uberall/grails-uber-doc/tree/master/grails-app/controllers/sample
+https://github.com/uberall/grails-uber-doc/tree/master/grails-app/domain/sample
+
+Once the annotations have been added to your code, a call to `UberDocService#getApiDocs` will return a Map structured around two main concepts: 
+
+* `resources`: contains information about the resources supported by your app. These information include supported HTTP methods (derived from `UrlMappings.groovy`), supported headers, possible errors (derived from the annotations you put on your controllers).
+* `objects`: holds information about the objects your app uses for transiting information. This derives from the annotations you put on your controllers and annotations put on your domain / POGO classes. That includes attributes contained on each object, their types (`String`, `Long`, etc) and constraints (e.g.: `maxSize: 20`, `nullable: false`), among other things.
+
+For example, if you run the integration test provided with the plugin, `UberDocService#getApiDocs` will return a map structured as follows (using JSON representation):
+
+```
+{
+    "resources": [
+        {
+            "baseMessageKey": "uberDoc.resource.api.something.else.POST",
+            "title": "uberDoc.api.something.else.POST.title",
+            "description": "uberDoc.resource.api.something.else.POST.description",
+            "uri": "/api/something/else",
+            "method": "POST",
+            "requestObject": "Pod",
+            "requestCollection": false,
+            "responseObject": "Pod",
+            "responseCollection": false,
+            "uriParams": [
+                {
+                    "name": "thirdId",
+                    "description": "uberDoc.resource.api.something.else.POST.uriParam.thirdId.description",
+                    "sampleValue": "uberDoc.resource.api.something.else.POST.uriParam.thirdId.sampleValue"
+                },
+                {
+                    "name": "firstId",
+                    "description": "uberDoc.resource.api.something.else.POST.uriParam.firstId.description",
+                    "sampleValue": "uberDoc.resource.api.something.else.POST.uriParam.firstId.sampleValue"
+                },
+                {
+                    "name": "secondId",
+                    "description": "uberDoc.resource.api.something.else.POST.uriParam.secondId.description",
+                    "sampleValue": "uberDoc.resource.api.something.else.POST.uriParam.secondId.sampleValue"
+                }
+            ],
+            "queryParams": [],
+            "bodyParams": [],
+            "headers": [
+                {
+                    "name": "some header param",
+                    "description": "uberDoc.resource.api.something.else.POST.header.some.header.param.description",
+                    "sampleValue": "uberDoc.resource.api.something.else.POST.header.some.header.param.sampleValue",
+                    "required": false
+                }
+            ],
+            "errors": []
+        },
+        {
+            "baseMessageKey": "uberDoc.resource.api.pods.$id.GET",
+            "title": "uberDoc.api.pods.$id.GET.title",
+            "description": "uberDoc.resource.api.pods.$id.GET.description",
+            "uri": "/api/pods/$id",
+            "method": "GET",
+            "requestObject": null,
+            "requestCollection": false,
+            "responseObject": "Pod",
+            "responseCollection": true,
+            "uriParams": [
+                {
+                    "name": "id",
+                    "description": "uberDoc.resource.api.pods.$id.GET.uriParam.id.description",
+                    "sampleValue": "uberDoc.resource.api.pods.$id.GET.uriParam.id.sampleValue"
+                }
+            ],
+            "queryParams": [],
+            "bodyParams": [],
+            "headers": [],
+            "errors": [
+                {
+                    "errorCode": "NF404",
+                    "httpCode": 404,
+                    "description": "uberDoc.resource.api.pods.$id.GET.error.404.description"
+                }
+            ]
+        },
+        {
+            "baseMessageKey": "uberDoc.resource.api.pods.POST",
+            "title": "uberDoc.api.pods.POST.title",
+            "description": "uberDoc.resource.api.pods.POST.description",
+            "uri": "/api/pods",
+            "method": "POST",
+            "requestObject": "Pod",
+            "requestCollection": false,
+            "responseObject": "Pod",
+            "responseCollection": false,
+            "uriParams": [
+                {
+                    "name": "thirdId",
+                    "description": "uberDoc.resource.api.pods.POST.uriParam.thirdId.description",
+                    "sampleValue": "uberDoc.resource.api.pods.POST.uriParam.thirdId.sampleValue"
+                },
+                {
+                    "name": "firstId",
+                    "description": "uberDoc.resource.api.pods.POST.uriParam.firstId.description",
+                    "sampleValue": "uberDoc.resource.api.pods.POST.uriParam.firstId.sampleValue"
+                },
+                {
+                    "name": "secondId",
+                    "description": "uberDoc.resource.api.pods.POST.uriParam.secondId.description",
+                    "sampleValue": "uberDoc.resource.api.pods.POST.uriParam.secondId.sampleValue"
+                }
+            ],
+            "queryParams": [],
+            "bodyParams": [
+                {
+                    "name": "firstBody",
+                    "description": "uberDoc.resource.api.pods.POST.bodyParam.firstBody.description",
+                    "sampleValue": "uberDoc.resource.api.pods.POST.bodyParam.firstBody.sampleValue",
+                    "type": "Long",
+                    "required": true
+                },
+                {
+                    "name": "secondBody",
+                    "description": "2nd body desc",
+                    "sampleValue": "body",
+                    "type": "String",
+                    "required": false
+                }
+            ],
+            "headers": [
+                {
+                    "name": "some header param",
+                    "description": "my header",
+                    "sampleValue": "my sample value",
+                    "required": false
+                }
+            ],
+            "errors": [
+                {
+                    "errorCode": "NF404",
+                    "httpCode": 404,
+                    "description": "my sample error"
+                }
+            ]
+        },
+        {
+            "baseMessageKey": "uberDoc.resource.api.pods.GET",
+            "title": "custom title for list resource",
+            "description": "custom description for list resource",
+            "uri": "/api/pods",
+            "method": "GET",
+            "requestObject": null,
+            "requestCollection": false,
+            "responseObject": "Pod",
+            "responseCollection": true,
+            "uriParams": [],
+            "queryParams": [
+                {
+                    "name": "max",
+                    "description": "uberDoc.resource.api.pods.GET.queryParam.max.description",
+                    "sampleValue": "uberDoc.resource.api.pods.GET.queryParam.max.sampleValue",
+                    "required": true
+                },
+                {
+                    "name": "page",
+                    "description": "custom description",
+                    "sampleValue": "custom value",
+                    "required": false
+                }
+            ],
+            "bodyParams": [],
+            "headers": [
+                {
+                    "name": "hdr",
+                    "description": "uberDoc.resource.api.pods.GET.header.hdr.description",
+                    "sampleValue": "uberDoc.resource.api.pods.GET.header.hdr.sampleValue",
+                    "required": false
+                }
+            ],
+            "errors": []
+        },
+        {
+            "baseMessageKey": "uberDoc.resource.api.pods.$id.DELETE",
+            "title": "uberDoc.api.pods.$id.DELETE.title",
+            "description": "uberDoc.resource.api.pods.$id.DELETE.description",
+            "uri": "/api/pods/$id",
+            "method": "DELETE",
+            "requestObject": null,
+            "requestCollection": false,
+            "responseObject": null,
+            "responseCollection": false,
+            "uriParams": [
+                {
+                    "name": "id",
+                    "description": "uberDoc.resource.api.pods.$id.DELETE.uriParam.id.description",
+                    "sampleValue": "uberDoc.resource.api.pods.$id.DELETE.uriParam.id.sampleValue"
+                }
+            ],
+            "queryParams": [],
+            "bodyParams": [],
+            "headers": [],
+            "errors": []
+        },
+        {
+            "baseMessageKey": "uberDoc.resource.api.pods.$id.PUT",
+            "title": "uberDoc.api.pods.$id.PUT.title",
+            "description": "uberDoc.resource.api.pods.$id.PUT.description",
+            "uri": "/api/pods/$id",
+            "method": "PUT",
+            "requestObject": "Pod",
+            "requestCollection": false,
+            "responseObject": "Pod",
+            "responseCollection": false,
+            "uriParams": [
+                {
+                    "name": "id",
+                    "description": "custom description for id",
+                    "sampleValue": "custom sample value for id"
+                }
+            ],
+            "queryParams": [
+                {
+                    "name": "foobar",
+                    "description": "uberDoc.resource.api.pods.$id.PUT.queryParam.foobar.description",
+                    "sampleValue": "uberDoc.resource.api.pods.$id.PUT.queryParam.foobar.sampleValue",
+                    "required": false
+                }
+            ],
+            "bodyParams": [],
+            "headers": [
+                {
+                    "name": "hdr",
+                    "description": "uberDoc.resource.api.pods.$id.PUT.header.hdr.description",
+                    "sampleValue": "uberDoc.resource.api.pods.$id.PUT.header.hdr.sampleValue",
+                    "required": false
+                }
+            ],
+            "errors": []
+        }
+    ],
+    "objects": {
+        "Pod": {
+            "name": "Pod",
+            "description": "overriden description for model",
+            "properties": [
+                {
+                    "name": "shared",
+                    "description": "uberDoc.object.Pod.shared.description",
+                    "sampleValue": "uberDoc.object.Pod.shared.sampleValue",
+                    "required": false,
+                    "type": "String",
+                    "constraints": [
+                        {
+                            "constraint": "nullable",
+                            "value": false
+                        }
+                    ]
+                },
+                {
+                    "name": "license",
+                    "description": "uberDoc.object.Pod.license.description",
+                    "sampleValue": "uberDoc.object.Pod.license.sampleValue",
+                    "required": true,
+                    "type": "String",
+                    "constraints": [
+                        {
+                            "constraint": "blank",
+                            "value": true
+                        },
+                        {
+                            "constraint": "nullable",
+                            "value": false
+                        }
+                    ]
+                },
+                {
+                    "name": "botName",
+                    "description": "botName has a description",
+                    "sampleValue": "botName has a sample value",
+                    "required": false,
+                    "type": "String",
+                    "constraints": [
+                        {
+                            "constraint": "custom",
+                            "value": "uberDoc.object.Pod.constraints.custom"
+                        },
+                        {
+                            "constraint": "nullable",
+                            "value": false
+                        }
+                    ]
+                },
+                {
+                    "name": "dateCreated",
+                    "type": "Date",
+                    "description": "uberDoc.object.Pod.dateCreated.description",
+                    "sampleValue": "uberDoc.object.Pod.dateCreated.sampleValue",
+                    "required": false
+                },
+                {
+                    "name": "inherited",
+                    "type": "String",
+                    "description": "uberDoc.object.Pod.inherited.description",
+                    "sampleValue": "uberDoc.object.Pod.inherited.sampleValue",
+                    "required": false
+                },
+                {
+                    "name": "id",
+                    "type": "Long",
+                    "description": "uberDoc.object.Pod.id.description",
+                    "sampleValue": "uberDoc.object.Pod.id.sampleValue",
+                    "required": false
+                }
+            ]
+        }
+    }
+}
+```
+
+##### Internal Only documentation:
+In order to provide internal only documentation, `internalOnly` is supported by the following annotations:
+- @UberDocController
+- @UberDocModel
+- @UberDocProperty
+- @UberDocResource
+
+Example: `@UberDocController(internalOnly = true)`
+
+Internal only documentation can be published by setting `uberdoc.publishInternalOnly` to `true` inside application.yml or application.groovy.
+
+
+###### Made with <3 in Berlin

--- a/src/main/groovy/uberdoc/ApiDocumentation.groovy
+++ b/src/main/groovy/uberdoc/ApiDocumentation.groovy
@@ -1,0 +1,74 @@
+package uberdoc
+
+class ApiDocumentation {
+    Map objects
+    List<Map> resources
+    List<Map.Entry> resourcesByObjects
+
+    ApiDocumentation(Map objects, List resources) {
+        this.objects = objects
+        this.resources = resources
+        sort()
+    }
+
+    private void sort() {
+        sortResourcesProperties()
+        sortObjectsProperties()
+
+        if (resources) {
+            resources = resources.sort { "${it.uri} ${getOrderNumber(it.method as String)}" }
+            resourcesByObjects = resources.groupBy { resource ->
+                return resource.uri.split("/")[2]
+            }.entrySet().toList() as List<Map.Entry>
+        }
+        if (objects) {
+            objects = objects.sort { it.value.name }
+        }
+    }
+
+    private void sortObjectsProperties() {
+        if (!objects) {
+            return
+        }
+
+        objects.each { Map.Entry object ->
+            object.value.properties.sort { it.name }
+        }
+    }
+
+    private void sortResourcesProperties() {
+        if (!resources) {
+            return
+        }
+
+        resources.each { Map resource ->
+            resource.queryParams.sort { it.name }
+            resource.uriParams.sort { it.name }
+            resource.bodyParams.sort { it.name }
+        }
+    }
+
+    /**
+     * Simple helper method to give all possible API methods (GET, PATCH, PUT, POST, DELETE) a specific order (not an alphabetically one)
+     * Each method will be represented by an int value ranging from 0 to 4
+     * For everything else besides the listed methods 99 will be returned
+     * @param method
+     * @return
+     */
+    private static int getOrderNumber(String method) {
+        switch (method) {
+            case 'GET':
+                return 0
+            case 'POST':
+                return 1
+            case 'PUT':
+                return 2
+            case 'PATCH':
+                return 3
+            case 'DELETE':
+                return 4
+            default:
+                return 99
+        }
+    }
+}

--- a/src/main/groovy/uberdoc/metadata/MethodReader.groovy
+++ b/src/main/groovy/uberdoc/metadata/MethodReader.groovy
@@ -1,7 +1,7 @@
 package uberdoc.metadata
 
-import groovy.json.JsonException
 import groovy.json.JsonSlurper
+import org.springframework.context.MessageSource
 import uberdoc.annotation.*
 import uberdoc.messages.MessageFallback
 import uberdoc.messages.MessageReader
@@ -11,22 +11,22 @@ import uberdoc.messages.MessageReader
  */
 class MethodReader {
 
-    def method
-    def messageSource
-    String uri
-    String uriMessageKey
-    MetadataReader reader
-    Locale locale
-    MessageReader messageReader
     MessageFallback fallback
     String httpMethod
+    Locale locale
+    def method
+    MessageReader messageReader
+    MessageSource messageSource
+    MetadataReader reader
+    String uri
+    String uriMessageKey
 
-    MethodReader(m, ms, mappingUri, mappingMethod) {
+    MethodReader(m, ms, mappingUri, mappingMethod, Locale locale = Locale.default) {
         reader = new MetadataReader()
         method = m
         messageSource = ms
 
-        locale = Locale.default
+        this.locale = locale
         messageReader = new MessageReader(messageSource, locale)
         fallback = new MessageFallback(messageReader)
 
@@ -146,8 +146,8 @@ class MethodReader {
             return [:]
         }
         return [
-                errorCode: err.errorCode(),
-                httpCode: err.httpCode(),
+                errorCode  : err.errorCode(),
+                httpCode   : err.httpCode(),
                 description: fallbackToMessageSourceIfAnnotationDoesNotOverride("uberDoc.resource.${uriMessageKey}.error.${err.httpCode()}.description", err.description())
         ]
     }
@@ -175,10 +175,10 @@ class MethodReader {
             return [:]
         }
         return [
-                name: hdr.name(),
+                name       : hdr.name(),
                 description: fallbackToMessageSourceIfAnnotationDoesNotOverride("uberDoc.resource.${uriMessageKey}.header.${hdr.name()}.description", hdr.description()),
                 sampleValue: fallbackToMessageSourceIfAnnotationDoesNotOverride("uberDoc.resource.${uriMessageKey}.header.${hdr.name()}.sampleValue", hdr.sampleValue()),
-                required: hdr.required()
+                required   : hdr.required()
         ]
     }
 
@@ -205,7 +205,7 @@ class MethodReader {
             return [:]
         }
         return [
-                name: urip.name(),
+                name       : urip.name(),
                 description: fallbackToMessageSourceIfAnnotationDoesNotOverride("uberDoc.resource.${uriMessageKey}.uriParam.${urip.name()}.description", urip.description()),
                 sampleValue: fallbackToMessageSourceIfAnnotationDoesNotOverride("uberDoc.resource.${uriMessageKey}.uriParam.${urip.name()}.sampleValue", urip.sampleValue())
         ]
@@ -277,15 +277,15 @@ class MethodReader {
     private void replaceUriParams() {
         List<String> uriParamNames = []
 
-        if (reader.getAnnotation(UberDocUriParams).inMethod(method)){
+        if (reader.getAnnotation(UberDocUriParams).inMethod(method)) {
             uriParamNames.addAll(reader.getAnnotation(UberDocUriParams).inMethod(method).value().collect { it.name() })
         }
 
-        if (reader.getAnnotation(UberDocUriParam).inMethod(method)){
+        if (reader.getAnnotation(UberDocUriParam).inMethod(method)) {
             uriParamNames.add(reader.getAnnotation(UberDocUriParam).inMethod(method).name())
         }
 
-        if (uriParamNames.size() == 0){
+        if (uriParamNames.size() == 0) {
             return
         }
 
@@ -294,7 +294,7 @@ class MethodReader {
         }
     }
 
-    private String fallbackToMessageSourceIfAnnotationDoesNotOverride(String messageKey, String annotatedValue){
+    private String fallbackToMessageSourceIfAnnotationDoesNotOverride(String messageKey, String annotatedValue) {
         return fallback.fallbackToMessageSourceIfAnnotationDoesNotOverride(messageKey, annotatedValue)
     }
 }

--- a/src/main/groovy/uberdoc/parser/UberDocResourceParser.groovy
+++ b/src/main/groovy/uberdoc/parser/UberDocResourceParser.groovy
@@ -1,5 +1,6 @@
 package uberdoc.parser
 
+import org.springframework.context.MessageSource
 import uberdoc.metadata.MethodReader
 
 /**
@@ -8,15 +9,17 @@ import uberdoc.metadata.MethodReader
  */
 class UberDocResourceParser {
 
+    Locale locale
     MethodReader methodReader
-    def messageSource
+    MessageSource messageSource
 
-    UberDocResourceParser(ms) {
+    UberDocResourceParser(MessageSource ms, Locale locale = Locale.default) {
         messageSource = ms
+        this.locale = locale
     }
 
     Map parse(controllerMethod, mapping) {
-        methodReader = new MethodReader(controllerMethod, messageSource, mapping.uri, mapping.method)
+        methodReader = new MethodReader(controllerMethod, messageSource, mapping.uri, mapping.method, locale)
 
         [baseMessageKey    : methodReader.baseMessageKey,
          title             : methodReader.resourceTitle,

--- a/src/test/groovy/uberdoc/metadata/MethodReaderSpec.groovy
+++ b/src/test/groovy/uberdoc/metadata/MethodReaderSpec.groovy
@@ -19,8 +19,8 @@ class MethodReaderSpec extends Specification {
         }, messageSourceMock, '/api/pods/(*)', 'GET')
 
         then:
-        '/api/pods/$id' == reader.uri
-        'api.pods.$id.GET' == reader.uriMessageKey
+        reader.uri == '/api/pods/$id'
+        reader.uriMessageKey == 'api.pods.$id.GET'
     }
 
     void "useLocale overrides default locale"() {
@@ -30,11 +30,11 @@ class MethodReaderSpec extends Specification {
         }, messageSourceMock, '/api/pods/(*)', 'GET')
 
         when:
-        def r = reader.useLocale(Locale.CANADA_FRENCH)
+        MethodReader r = reader.useLocale(Locale.CANADA_FRENCH)
 
         then:
         r == reader
-        Locale.CANADA_FRENCH == r.locale
+        r.locale == Locale.CANADA_FRENCH
         Locale.default != r.locale
     }
 
@@ -45,7 +45,7 @@ class MethodReaderSpec extends Specification {
         }, messageSourceMock, '/api/pods/(*)', 'GET')
 
         then:
-        Locale.default == reader.locale
+        reader.locale == Locale.default
     }
 
     void "getResourceDescription returns message for key"() {
@@ -59,7 +59,8 @@ class MethodReaderSpec extends Specification {
         String desc = reader.resourceDescription
 
         then:
-        'description set by message' == desc
+        desc == 'description set by message'
+
         1 * messageSourceMock.getMessage('uberDoc.resource.api.pods.$id.GET.description', new Object[0], Locale.default) >> "description set by message"
     }
 
@@ -73,7 +74,8 @@ class MethodReaderSpec extends Specification {
         String desc = reader.resourceDescription
 
         then:
-        'custom description for list resource' == desc
+        desc == 'custom description for list resource'
+
         1 * messageSourceMock.getMessage('uberDoc.resource.api.pods.GET.description', new Object[0], Locale.default) >> 'uberDoc.resource.api.pods.GET.description'
     }
 
@@ -88,7 +90,8 @@ class MethodReaderSpec extends Specification {
         String desc = reader.resourceTitle
 
         then:
-        'title set by message' == desc
+        desc == 'title set by message'
+
         1 * messageSourceMock.getMessage('uberDoc.api.pods.$id.GET.title', new Object[0], Locale.default) >> "title set by message"
     }
 
@@ -102,7 +105,8 @@ class MethodReaderSpec extends Specification {
         String desc = reader.resourceTitle
 
         then:
-        'custom title for list resource' == desc
+        desc == 'custom title for list resource'
+
         1 * messageSourceMock.getMessage('uberDoc.api.pods.GET.title', new Object[0], Locale.default) >> 'uberDoc.api.pods.GET.title'
     }
 
@@ -113,7 +117,7 @@ class MethodReaderSpec extends Specification {
         }, messageSourceMock, '/api/pods/', 'POST')
 
         then:
-        "Pod" == reader.requestObject
+        reader.requestObject == "Pod"
     }
 
     void "getRequestObject uses requestObject"() {
@@ -123,7 +127,7 @@ class MethodReaderSpec extends Specification {
         }, messageSourceMock, '/api/pods/(*)', 'GET')
 
         then:
-        "Pod" == reader.requestObject
+        reader.requestObject == "Pod"
     }
 
     void "getRequestObject returns null if method has no request object"() {
@@ -153,7 +157,7 @@ class MethodReaderSpec extends Specification {
         }, messageSourceMock, '/api/pods/', 'POST')
 
         then:
-        "Pod" == reader.responseObject
+        reader.responseObject == "Pod"
     }
 
     void "getResponseObject uses responseObject"() {
@@ -163,7 +167,7 @@ class MethodReaderSpec extends Specification {
         }, messageSourceMock, '/api/pods/', 'GET')
 
         then:
-        "Pod" == reader.responseObject
+        reader.responseObject == "Pod"
     }
 
     void "getResponseObject returns null if method has no response object"() {
@@ -193,13 +197,14 @@ class MethodReaderSpec extends Specification {
         }, messageSourceMock, '/api/pods/(*)', 'GET')
 
         when:
-        def err = reader.errors
+        List<Map> err = reader.errors
 
         then:
-        1 == err.size()
-        "description in message" == err[0].description
-        "NF404" == err[0].errorCode
-        404 == err[0].httpCode
+        err.size() == 1
+        err[0].description == "description in message"
+        err[0].errorCode == "NF404"
+        err[0].httpCode == 404
+
         1 * messageSourceMock.getMessage('uberDoc.resource.api.pods.$id.GET.error.404.description', new Object[0], Locale.default) >> "description in message"
     }
 
@@ -210,13 +215,14 @@ class MethodReaderSpec extends Specification {
         }, messageSourceMock, '/api/pods/', 'POST')
 
         when:
-        def err = reader.errors
+        List<Map> err = reader.errors
 
         then:
-        1 == err.size()
-        "my sample error" == err[0].description
-        "NF404" == err[0].errorCode
-        404 == err[0].httpCode
+        err.size() == 1
+        err[0].description == "my sample error"
+        err[0].errorCode == "NF404"
+        err[0].httpCode == 404
+
         1 * messageSourceMock.getMessage('uberDoc.resource.api.pods.POST.error.404.description', new Object[0], Locale.default) >> 'uberDoc.resource.api.pods.POST.error.404.description'
     }
 
@@ -227,13 +233,14 @@ class MethodReaderSpec extends Specification {
         }, messageSourceMock, '/api/pods/', 'GET')
 
         when:
-        def headers = reader.headers
+        List<Map> headers = reader.headers
 
         then:
-        1 == headers.size()
+        headers.size() == 1
+        headers[0].name == "hdr"
+        headers[0].sampleValue == "sampleValue in message"
+
         1 * messageSourceMock.getMessage('uberDoc.resource.api.pods.GET.header.hdr.sampleValue', new Object[0], Locale.default) >> "sampleValue in message"
-        "hdr" == headers[0].name
-        "sampleValue in message" == headers[0].sampleValue
     }
 
     void "getHeaders works properly with custom value"() {
@@ -243,13 +250,14 @@ class MethodReaderSpec extends Specification {
         }, messageSourceMock, '/api/pods/', 'POST')
 
         when:
-        def headers = reader.headers
+        List<Map> headers = reader.headers
 
         then:
-        1 == headers.size()
-        "some header param" == headers[0].name
-        "my header" == headers[0].description
-        "my sample value" == headers[0].sampleValue
+        headers.size() == 1
+        headers[0].name == "some header param"
+        headers[0].description == "my header"
+        headers[0].sampleValue == "my sample value"
+
         1 * messageSourceMock.getMessage('uberDoc.resource.api.pods.POST.header.some.header.param.description', new Object[0], Locale.default) >> "uberDoc.resource.api.pods.POST.header.some.header.param.description"
         1 * messageSourceMock.getMessage('uberDoc.resource.api.pods.POST.header.some.header.param.sampleValue', new Object[0], Locale.default) >> "uberDoc.resource.api.pods.POST.header.some.header.param.sampleValue"
     }
@@ -271,15 +279,16 @@ class MethodReaderSpec extends Specification {
         }, messageSourceMock, '/api/pods/(*)', 'GET')
 
         when:
-        def uriParams = reader.uriParams
+        List<Map> uriParams = reader.uriParams
 
         then:
-        1 == uriParams.size()
+        uriParams.size() == 1
+        uriParams[0].name == "id"
+        uriParams[0].description == "description in message"
+        uriParams[0].sampleValue == "sampleValue in message"
+
         1 * messageSourceMock.getMessage('uberDoc.resource.api.pods.$id.GET.uriParam.id.description', new Object[0], Locale.default) >> "description in message"
         1 * messageSourceMock.getMessage('uberDoc.resource.api.pods.$id.GET.uriParam.id.sampleValue', new Object[0], Locale.default) >> "sampleValue in message"
-        "id" == uriParams[0].name
-        "description in message" == uriParams[0].description
-        "sampleValue in message" == uriParams[0].sampleValue
     }
 
     void "getUriParams works properly with custom values"() {
@@ -289,14 +298,14 @@ class MethodReaderSpec extends Specification {
         }, messageSourceMock, '/api/pods/(*)', 'PATCH')
 
         when:
-        def uriParams = reader.uriParams
+        List<Map> uriParams = reader.uriParams
 
         then:
-        1 == uriParams.size()
+        uriParams.size() == 1
 
-        "id" == uriParams[0].name
-        "custom description for id" == uriParams[0].description
-        "custom sample value for id" == uriParams[0].sampleValue
+        uriParams[0].name == "id"
+        uriParams[0].description == "custom description for id"
+        uriParams[0].sampleValue == "custom sample value for id"
 
         1 * messageSourceMock.getMessage('uberDoc.resource.api.pods.$id.PATCH.uriParam.id.description', new Object[0], Locale.default) >> 'uberDoc.resource.api.pods.$id.PATCH.uriParam.id.description'
         1 * messageSourceMock.getMessage('uberDoc.resource.api.pods.$id.PATCH.uriParam.id.sampleValue', new Object[0], Locale.default) >> 'uberDoc.resource.api.pods.$id.PATCH.uriParam.id.sampleValue'
@@ -310,8 +319,8 @@ class MethodReaderSpec extends Specification {
 
         then:
         reader.uriParams
-        3 == reader.uriParams.size()
-        ["firstId", "secondId", "thirdId"].containsAll(reader.uriParams.name)
+        reader.uriParams.size() == 3
+        reader.uriParams.name.containsAll(["firstId", "secondId", "thirdId"])
     }
 
     void "getUriParams returns nothing if method does not have the annotation"() {
@@ -331,15 +340,16 @@ class MethodReaderSpec extends Specification {
         }, messageSourceMock, '/api/pods/(*)', 'PATCH')
 
         when:
-        def qry = reader.queryParams
+        List<Map> qry = reader.queryParams
 
         then:
-        1 == qry.size()
-        "foobar" == qry[0].name
+        qry.size() == 1
+        qry[0].name == "foobar"
+        qry[0].description == "description in message"
+        qry[0].sampleValue == "sampleValue in message"
+
         1 * messageSourceMock.getMessage('uberDoc.resource.api.pods.$id.PATCH.queryParam.foobar.description', new Object[0], Locale.default) >> "description in message"
         1 * messageSourceMock.getMessage('uberDoc.resource.api.pods.$id.PATCH.queryParam.foobar.sampleValue', new Object[0], Locale.default) >> "sampleValue in message"
-        "description in message" == qry[0].description
-        "sampleValue in message" == qry[0].sampleValue
     }
 
     void "getQueryParams works properly with custom description and sample value"() {
@@ -349,20 +359,20 @@ class MethodReaderSpec extends Specification {
         }, messageSourceMock, '/api/pods/', 'GET')
 
         when:
-        def qry = reader.queryParams
+        List<Map> qry = reader.queryParams
 
         then:
-        2 == qry.size()
+        qry.size() == 2
 
-        "max" == qry[0].name
+        qry[0].name == "max"
         qry[0].required
-        "description in message" == qry[0].description
-        "sampleValue in message" == qry[0].sampleValue
+        qry[0].description == "description in message"
+        qry[0].sampleValue == "sampleValue in message"
 
-        "page" == qry[1].name
+        qry[1].name == "page"
         !qry[1].required
-        "custom description" == qry[1].description
-        "custom value" == qry[1].sampleValue
+        qry[1].description == "custom description"
+        qry[1].sampleValue == "custom value"
 
         1 * messageSourceMock.getMessage('uberDoc.resource.api.pods.GET.queryParam.max.description', new Object[0], Locale.default) >> "description in message"
         1 * messageSourceMock.getMessage('uberDoc.resource.api.pods.GET.queryParam.max.sampleValue', new Object[0], Locale.default) >> "sampleValue in message"
@@ -378,9 +388,9 @@ class MethodReaderSpec extends Specification {
 
         then:
         reader.queryParams
-        2 == reader.queryParams.size()
-        ["page", "max"].containsAll(reader.queryParams.name)
-        [true, false].containsAll(reader.queryParams.required)
+        reader.queryParams.size() == 2
+        reader.queryParams.name.containsAll(["page", "max"])
+        reader.queryParams.required.containsAll([true, false])
     }
 
     void "getQueryParams returns nothing if method does not have the annotation"() {
@@ -400,18 +410,18 @@ class MethodReaderSpec extends Specification {
         }, messageSourceMock, '/api/pods/', 'POST')
 
         when:
-        def bodyParams = reader.bodyParams
+        List<Map> bodyParams = reader.bodyParams
 
         then:
-        2 == bodyParams.size()
+        bodyParams.size() == 2
 
-        "firstBody" == bodyParams[0].name
-        "description in message" == bodyParams[0].description
-        "sampleValue in message" == bodyParams[0].sampleValue
+        bodyParams[0].name == "firstBody"
+        bodyParams[0].description == "description in message"
+        bodyParams[0].sampleValue == "sampleValue in message"
 
-        "secondBody" == bodyParams[1].name
-        "2nd body desc" == bodyParams[1].description
-        "body" == bodyParams[1].sampleValue
+        bodyParams[1].name == "secondBody"
+        bodyParams[1].description == "2nd body desc"
+        bodyParams[1].sampleValue == "body"
 
         1 * messageSourceMock.getMessage('uberDoc.resource.api.pods.POST.bodyParam.firstBody.description', new Object[0], Locale.default) >> "description in message"
         1 * messageSourceMock.getMessage('uberDoc.resource.api.pods.POST.bodyParam.firstBody.sampleValue', new Object[0], Locale.default) >> "sampleValue in message"


### PR DESCRIPTION
build.gradle
- added grails-test-mixins for testCompile to enable possibility to run specs and integration specs locally

README.md
- old one moved to /readme_files/3_1_1.md
- changes README.md to reflect changes introduced with 3.2

ApiDocumentation.groovy
- added object itself
- object provides resources, resourcesByObject and objetcs
- provides constructor and sorting logic

UberDocService.groovy
- added logic for getting message keys for resources for given locale
- removed caching
- added Log4j Annotation to service class
- small refactoring

MethodReader.groovy
- added support for using different locale (not only using Locale.default)

UberDocResourceParser.groovy
- added support for using specific locale

UberDocServiceIntegrationSpec.groovy
MethodReaderSpec.groovy
- adjusted specs to make them green again
- refactored yoda speech
- small refactoring